### PR TITLE
Sync Postman collection on pr merge

### DIFF
--- a/.github/workflows/sync-postman-collection.yml
+++ b/.github/workflows/sync-postman-collection.yml
@@ -6,15 +6,9 @@ on:
       - main
     paths:
       - 'StackOne_postman_collection.json'
-  pull_request:
-    types: [closed]
-    paths:
-      - 'StackOne_postman_collection.json'
 
 jobs:
   sync-postman:
-    # Only run when PR is merged or direct push to main
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/sync-postman-collection.yml
+++ b/.github/workflows/sync-postman-collection.yml
@@ -1,0 +1,131 @@
+name: Sync Postman Collection
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'StackOne_postman_collection.json'
+  pull_request:
+    types: [closed]
+    paths:
+      - 'StackOne_postman_collection.json'
+
+jobs:
+  sync-postman:
+    # Only run when PR is merged or direct push to main
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install Newman (Postman CLI)
+        run: npm install -g newman
+      
+      - name: Check if collection exists in Postman
+        id: check_collection
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
+        run: |
+          # Get all collections in workspace
+          response=$(curl -s -X GET \
+            "https://api.getpostman.com/collections?workspace=$POSTMAN_WORKSPACE_ID" \
+            -H "X-Api-Key: $POSTMAN_API_KEY")
+          
+          # Check if StackOne collection exists
+          collection_uid=$(echo "$response" | jq -r '.collections[] | select(.name == "StackOne") | .uid' | head -1)
+          
+          if [ -n "$collection_uid" ]; then
+            echo "Collection exists with UID: $collection_uid"
+            echo "collection_exists=true" >> $GITHUB_OUTPUT
+            echo "collection_uid=$collection_uid" >> $GITHUB_OUTPUT
+          else
+            echo "Collection does not exist"
+            echo "collection_exists=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Update existing collection
+        if: steps.check_collection.outputs.collection_exists == 'true'
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          COLLECTION_UID: ${{ steps.check_collection.outputs.collection_uid }}
+        run: |
+          # Read the collection file
+          collection_json=$(cat StackOne_postman_collection.json)
+          
+          # Update the existing collection
+          response=$(curl -s -w "\n%{http_code}" -X PUT \
+            "https://api.getpostman.com/collections/$COLLECTION_UID" \
+            -H "X-Api-Key: $POSTMAN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"collection\": $collection_json}")
+          
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+          
+          if [ "$http_code" -eq 200 ]; then
+            echo "✅ Successfully updated collection"
+            echo "$body" | jq '.'
+          else
+            echo "❌ Failed to update collection. HTTP Code: $http_code"
+            echo "Response: $body"
+            exit 1
+          fi
+      
+      - name: Create new collection
+        if: steps.check_collection.outputs.collection_exists == 'false'
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
+        run: |
+          # Read the collection file
+          collection_json=$(cat StackOne_postman_collection.json)
+          
+          # Create new collection
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "https://api.getpostman.com/collections?workspace=$POSTMAN_WORKSPACE_ID" \
+            -H "X-Api-Key: $POSTMAN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"collection\": $collection_json}")
+          
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+          
+          if [ "$http_code" -eq 200 ]; then
+            echo "✅ Successfully created new collection"
+            echo "$body" | jq '.'
+          else
+            echo "❌ Failed to create collection. HTTP Code: $http_code"
+            echo "Response: $body"
+            exit 1
+          fi
+      
+      - name: Verify sync
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_WORKSPACE_ID: ${{ secrets.POSTMAN_WORKSPACE_ID }}
+        run: |
+          echo "🔍 Verifying collection sync..."
+          
+          # Get collections again to verify
+          response=$(curl -s -X GET \
+            "https://api.getpostman.com/collections?workspace=$POSTMAN_WORKSPACE_ID" \
+            -H "X-Api-Key: $POSTMAN_API_KEY")
+          
+          stackone_collection=$(echo "$response" | jq '.collections[] | select(.name == "StackOne")')
+          
+          if [ -n "$stackone_collection" ]; then
+            echo "✅ Collection verified in workspace"
+            echo "$stackone_collection" | jq '.'
+          else
+            echo "❌ Collection not found after sync"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ To use the Postman collection, follow these steps:
 - **Collection Name:** StackOne
 - **Schema Version:** [Postman Collection Schema v2.1.0](https://schema.getpostman.com/json/collection/v2.1.0/collection.json)
 
+## Automated Sync to Postman
+
+This repository includes a GitHub workflow that automatically syncs the Postman collection to your Postman workspace when changes are merged to the main branch.
+
+### Setup Requirements
+
+To enable automatic synchronization, you need to configure the following GitHub secrets in your repository:
+
+1. **`POSTMAN_API_KEY`**: Your Postman API key
+   - Generate from: [Postman Account Settings](https://postman.co/settings/me/api-keys)
+   - Required permissions: Collection management
+
+2. **`POSTMAN_WORKSPACE_ID`**: Your Postman workspace ID
+   - Find in Postman: Go to your workspace → Settings → Info → Workspace ID
+   - Or via API: `GET https://api.getpostman.com/workspaces`
+
+### How It Works
+
+- The workflow triggers when changes to `StackOne_postman_collection.json` are pushed to the main branch or when a PR containing changes to this file is merged
+- If a collection named "StackOne" exists in your workspace, it will be updated
+- If no collection exists, a new one will be created
+- The workflow uses the official Postman API for all operations
+
 ## Contributing
 
 If you find any issues or have suggestions for improvements, please submit an issue or pull request on this repository.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To enable automatic synchronization, you need to configure the following GitHub 
 
 ### How It Works
 
-- The workflow triggers when changes to `StackOne_postman_collection.json` are pushed to the main branch or when a PR containing changes to this file is merged
+- The workflow triggers when changes to `StackOne_postman_collection.json` are pushed to the main branch (including PR merges)
 - If a collection named "StackOne" exists in your workspace, it will be updated
 - If no collection exists, a new one will be created
 - The workflow uses the official Postman API for all operations


### PR DESCRIPTION
Add a GitHub workflow to automatically sync the `StackOne_postman_collection.json` to Postman.

This provides a free alternative for auto-syncing Postman collections from GitHub, as Postman's lower tiers do not offer direct repository integration.

---
[Slack Thread](https://stackonehq.slack.com/archives/D093NBXS9C1/p1757080308820669?thread_ts=1757080308.820669&cid=D093NBXS9C1)

<a href="https://cursor.com/background-agent?bcId=bc-4e1503f9-5f73-4bc4-8131-590fde061789">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e1503f9-5f73-4bc4-8131-590fde061789">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a GitHub Actions workflow to auto-sync StackOne_postman_collection.json to the "StackOne" collection in Postman when changes merge to main. Updates README with quick setup steps; uses the Postman API (no paid Postman integration needed).

- **New Features**
  - Syncs on push to main or merged PR that changes StackOne_postman_collection.json.
  - Updates the existing "StackOne" collection or creates it in the given workspace, then verifies via the Postman API.

- **Migration**
  - Add repo secrets: POSTMAN_API_KEY and POSTMAN_WORKSPACE_ID.

<!-- End of auto-generated description by cubic. -->

