### PR TITLE
Pinning GitHub actions

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -15,7 +15,7 @@ permissions:
     - cron: 0 0 * * *
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@3fdab59e74dda7831d7401f7aa1bb55d706913d7 # v15
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins the SDK generation GitHub Action to a specific commit to enforce reproducible runs and meet ENG-11298’s org-wide action pinning policy. Replaces the v15 tag with commit 3fdab59e74dda7831d7401f7aa1bb55d706913d7 (# v15) to prevent tag drift.

<sup>Written for commit c71efcfc9672e6dac821cf6cb8449c3b5152b0fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

